### PR TITLE
fix data race on outputStream

### DIFF
--- a/Sources/Net/NetSocket.swift
+++ b/Sources/Net/NetSocket.swift
@@ -109,12 +109,14 @@ open class NetSocket: NSObject {
     }
 
     func close(isDisconnected: Bool) {
-        outputQueue.async {
+        inputQueue.suspend()
+        outputQueue.sync {
             guard self.runloop != nil else {
                 return
             }
             self.deinitConnection(isDisconnected: isDisconnected)
         }
+        inputQueue.resume()
     }
 
     func initConnection() {


### PR DESCRIPTION
The data race seems to be occurring on the `outputStream`.
To avoid this, suspend the `inputQueue` while the `deinitConnection` is running.